### PR TITLE
replace appId with appName in configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -97,14 +97,18 @@ tunnel:
       url: https://ipinfo.io/ip
 
 # Specify which applications can be accessed by remote peer sites.
-# The both options id and socket are required
+# The both options appName and appSocket are required.
+# The max lenght of appName is 255, and appName must be unique
+# in the local site. The appSocket is the socket of the local application
 # 指定本端哪些应用可以被远程对等站点访问
-# 两个参数 id 和  socket 都是必须被设置的
+# 两个参数 appName 和 appSocket 都是必须被设置的
+# appName 的最大长度是 255，且在本地站点中必须唯一
+# appSocket 是本地应用的套接字
 localExposedApps:
-- socket: 192.168.122.80:8080
-  id: 1562160a-7e84-4d32-8912-d8bdc96f47aa
-- socket: 127.0.0.1:22
-  id: 16d86618-d4f3-4221-9ed2-7f4534774082
+- appSocket: 192.168.122.80:8080
+  appName: web
+- appSocket: 127.0.0.1:22
+  appName: ssh
 
 # Specify the local site can access which remote applications of remote sites
 # All these three options are required.
@@ -116,8 +120,8 @@ localExposedApps:
 # 特定的远端应用。
 remoteApps:
 - siteName: site02
-  remoteAppId: 2559c7cf-b571-42ca-81ee-8de47515c6c5
+  appName: web
   localSocket: 127.0.0.1:28080
 - siteName: site03
-  remoteAppId: 86d7cc3b-8eef-43e2-8625-4ad30f0cfb8f
+  appName: ssh
   localSocket: 127.0.0.1:20022

--- a/examples/reverse-proxy/README.md
+++ b/examples/reverse-proxy/README.md
@@ -48,10 +48,10 @@ tunnel:
 
 remoteApps:
 - siteName: private-01
-  remoteAppId: 25cad886-6edd-4ee8-a5dc-294b73649256
+  appName: web
   localSocket: 0.0.0.0:28080
 - siteName: private-02
-  remoteAppId: 31f62ddd-397a-4047-9dc0-2c316708561c
+  appName: ssh
   localSocket: 0.0.0.0:59822
 ```
 
@@ -75,8 +75,8 @@ messageChannel:
     topic: "kungze/wovenet/reverse-proxy-78yted"
 
 localExposedApps:
-- socket: 172.26.142.105:80
-  id: 25cad886-6edd-4ee8-a5dc-294b73649256
+- appSocket: 172.26.142.105:80
+  appName: web
 ```
 
 ### Private-02 Host Configuration
@@ -99,8 +99,8 @@ messageChannel:
     topic: "kungze/wovenet/reverse-proxy-78yted"
 
 localExposedApps:
-- socket: 192.168.1.2:22
-  id: 31f62ddd-397a-4047-9dc0-2c316708561c
+- appSocket: 192.168.1.2:22
+  appName: ssh
 ```
 
 Run the following command on all three hosts (execution order doesn't matter):

--- a/examples/reverse-proxy/README_zh.md
+++ b/examples/reverse-proxy/README_zh.md
@@ -48,10 +48,10 @@ tunnel:
 
 remoteApps:
 - siteName: private-01
-  remoteAppId: 25cad886-6edd-4ee8-a5dc-294b73649256
+  appName: web
   localSocket: 0.0.0.0:28080
 - siteName: private-02
-  remoteAppId: 31f62ddd-397a-4047-9dc0-2c316708561c
+  appName: ssh
   localSocket: 0.0.0.0:59822
 ```
 
@@ -75,9 +75,8 @@ messageChannel:
     topic: "kungze/wovenet/reverse-proxy-78yted"
 
 localExposedApps:
-- socket: 172.26.142.105:80
-  id: 25cad886-6edd-4ee8-a5dc-294b73649256
-
+- appSocket: 172.26.142.105:80
+  appName: web
 ```
 
 ### 内网主机 2 配置：
@@ -100,8 +99,8 @@ messageChannel:
     topic: "kungze/wovenet/reverse-proxy-78yted"
 
 localExposedApps:
-- socket: 192.168.1.2:22
-  id: 31f62ddd-397a-4047-9dc0-2c316708561c
+- appSocket: 192.168.1.2:22
+  appName: ssh
 ```
 
 在三个主机上分别执行命令（三个主机可以任意顺序执行）：

--- a/examples/v4-v6-dual-stack/README.md
+++ b/examples/v4-v6-dual-stack/README.md
@@ -69,8 +69,8 @@ tunnel:
     publicPort: 25890
 
 localExposedApps:
-- socket: 127.0.0.1:5201
-  id: afe87405-0f46-4290-84df-b6034b54761f
+- appSocket: 127.0.0.1:5201
+  appName: iperf
 ```
 
 **Note:**
@@ -121,7 +121,7 @@ tunnel:
 
 remoteApps:
 - siteName: aws
-  remoteAppId: afe87405-0f46-4290-84df-b6034b54761f
+  appName: iperf
   localSocket: 127.0.0.1:5201
 ```
 

--- a/examples/v4-v6-dual-stack/README_zh.md
+++ b/examples/v4-v6-dual-stack/README_zh.md
@@ -69,8 +69,8 @@ tunnel:
     publicPort: 25890
 
 localExposedApps:
-- socket: 127.0.0.1:5201
-  id: afe87405-0f46-4290-84df-b6034b54761f
+- appSocket: 127.0.0.1:5201
+  appName: iperf
 ```
 
 **注意：** 上面配置我们没有使用到 AWS 主机的公网 IPv4 地址，公网 IPv6 地址是这个主机专属的，并且直接配置在主机网卡上。需要在防火墙/安全组添加规则，放行 UDP 25890 端口。
@@ -119,7 +119,7 @@ tunnel:
 
 remoteApps:
 - siteName: aws
-  remoteAppId: afe87405-0f46-4290-84df-b6034b54761f
+  appName: iperf
   localSocket: 127.0.0.1:5201
 ```
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -7,39 +7,48 @@ import (
 )
 
 type LocalExposedAppConfig struct {
-	Id     string `mapstructure:"id"`
-	Socket string `mapstructure:"socket"`
+	AppName   string `mapstructure:"appName"`
+	AppSocket string `mapstructure:"appSocket"`
 }
 
 type RemoteAppConfig struct {
-	RemoteAppId string `mapstructure:"remoteAppId"`
-	LocalSocket string `mapstructure:"localSocket"`
 	SiteName    string `mapstructure:"siteName"`
+	AppName     string `mapstructure:"appName"`
+	LocalSocket string `mapstructure:"localSocket"`
 }
 
-var localExposedAppIds = []string{}
+var localExposedAppNames = []string{}
 
 func CheckLocalExposedAppConfig(configs []*LocalExposedAppConfig) error {
 	for _, cfg := range configs {
-		if cfg.Id == "" || cfg.Socket == "" {
-			return fmt.Errorf("the id and socket must set together for localExposedApp")
+		if cfg.AppName == "" || cfg.AppSocket == "" {
+			return fmt.Errorf("the appName and appsocket must be set together for local exposed app")
 		}
-		_, err := netip.ParseAddrPort(cfg.Socket)
+		if len(cfg.AppName) > 255 {
+			return fmt.Errorf("the appName: %s is too long, the max length is 255", cfg.AppName)
+		}
+		_, err := netip.ParseAddrPort(cfg.AppSocket)
 		if err != nil {
-			return fmt.Errorf("the socket: %s is invalid", cfg.Socket)
+			return fmt.Errorf("the app socket: %s is invalid", cfg.AppSocket)
 		}
-		if slices.Contains(localExposedAppIds, cfg.Id) {
-			return fmt.Errorf("the local exposed app id: %s is not unique", cfg.Id)
+		if slices.Contains(localExposedAppNames, cfg.AppName) {
+			return fmt.Errorf("the appName: %s is duplicated", cfg.AppName)
 		}
-		localExposedAppIds = append(localExposedAppIds, cfg.Id)
+		localExposedAppNames = append(localExposedAppNames, cfg.AppName)
 	}
 	return nil
 }
 
 func CheckRemoteAddConfig(configs []*RemoteAppConfig) error {
 	for _, cfg := range configs {
-		if cfg.RemoteAppId == "" || cfg.LocalSocket == "" || cfg.SiteName == "" {
-			return fmt.Errorf("the siteName and remoteAppId and localSocket must be set together for remoteApp")
+		if cfg.SiteName == "" || cfg.AppName == "" || cfg.LocalSocket == "" {
+			return fmt.Errorf("the siteName, appName and localSocket must be set together for remote app")
+		}
+		if len(cfg.SiteName) > 255 {
+			return fmt.Errorf("the siteName: %s is too long, the max length is 255", cfg.SiteName)
+		}
+		if len(cfg.AppName) > 255 {
+			return fmt.Errorf("the appName: %s is too long, the max length is 255", cfg.AppName)
 		}
 		_, err := netip.ParseAddrPort(cfg.LocalSocket)
 		if err != nil {

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -10,8 +10,8 @@ type localApp struct {
 
 // GetConnection get a connection which connect to the local app
 func (la *localApp) GetConnection() (net.Conn, error) {
-	network := networkType(la.config.Socket)
-	conn, err := net.Dial(network, la.config.Socket)
+	network := networkType(la.config.AppSocket)
+	conn, err := net.Dial(network, la.config.AppSocket)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -16,18 +16,18 @@ type AppManager struct {
 func (am *AppManager) GetExposedApps() []LocalExposedApp {
 	apps := []LocalExposedApp{}
 	for _, app := range am.localExposedApps {
-		apps = append(apps, LocalExposedApp{Id: app.config.Id})
+		apps = append(apps, LocalExposedApp{Name: app.config.AppName})
 	}
 	return apps
 }
 
 // ConnectToLocalApp get a connection which connect to the local app
-func (am *AppManager) ConnectToLocalApp(appId string) (io.ReadWriteCloser, error) {
+func (am *AppManager) ConnectToLocalApp(appName string) (io.ReadWriteCloser, error) {
 	log := logger.GetDefault()
-	app, ok := am.localExposedApps[appId]
+	app, ok := am.localExposedApps[appName]
 	if !ok {
-		log.Error("local app can not found", "appId", appId)
-		return nil, fmt.Errorf("app: %s can not found", appId)
+		log.Error("local app can not found", "localApp", appName)
+		return nil, fmt.Errorf("app: %s can not found", appName)
 	}
 	return app.GetConnection()
 }
@@ -41,10 +41,10 @@ func (am *AppManager) ProcessNewRemoteSite(ctx context.Context, remoteSite strin
 		if remoteApp.Active() {
 			continue
 		}
-		for _, eApp := range exposedApps {
-			if remoteApp.config.SiteName == remoteSite && remoteApp.config.RemoteAppId == eApp.Id {
+		for _, exposedApp := range exposedApps {
+			if remoteApp.config.SiteName == remoteSite && remoteApp.config.AppName == exposedApp.Name {
 				if err := remoteApp.listen(ctx, callback); err != nil {
-					log.Error("failed to start local socket listener for remote app", "localSocket", remoteApp.config.LocalSocket, "remoteSite", remoteSite, "remoteAppId", remoteApp.config.RemoteAppId, "error", err)
+					log.Error("failed to start local socket listener for remote app", "localSocket", remoteApp.config.LocalSocket, "remoteSite", remoteSite, "appName", remoteApp.config.AppName, "error", err)
 					continue
 				}
 			}
@@ -66,7 +66,7 @@ func NewAppManager(ctx context.Context, localexposedApps []*LocalExposedAppConfi
 	am := AppManager{localExposedApps: map[string]*localApp{}}
 	for _, exposedApp := range localexposedApps {
 		a := newLocalApp(*exposedApp)
-		am.localExposedApps[exposedApp.Id] = a
+		am.localExposedApps[exposedApp.AppName] = a
 	}
 
 	for _, remoteApp := range remoteApps {

--- a/internal/app/message.go
+++ b/internal/app/message.go
@@ -1,5 +1,5 @@
 package app
 
 type LocalExposedApp struct {
-	Id string `mapstructure:"id"`
+	Name string `mapstructure:"name"`
 }

--- a/internal/app/remote.go
+++ b/internal/app/remote.go
@@ -24,10 +24,10 @@ func (ra *remoteApp) listen(ctx context.Context, callback ClientConnectedCallbac
 	l, err := net.Listen(networkType, ra.config.LocalSocket)
 	if err != nil {
 		ra.active.Store(false)
-		log.Error("failed to listen local socket for remote app", "localSocket", ra.config.LocalSocket, "remoteAppId", ra.config.RemoteAppId, "error", err)
+		log.Error("failed to listen local socket for remote app", "localSocket", ra.config.LocalSocket, "remoteApp", ra.config.AppName, "error", err)
 		return err
 	}
-	log.Info("listen local socket for remote app", "localSocket", ra.config.LocalSocket, "remoteSite", ra.config.SiteName, "remoteAppId", ra.config.RemoteAppId)
+	log.Info("listen local socket for remote app", "localSocket", ra.config.LocalSocket, "remoteSite", ra.config.SiteName, "remoteApp", ra.config.AppName)
 	ra.listener = l
 	go func() {
 		defer func() {
@@ -41,11 +41,11 @@ func (ra *remoteApp) listen(ctx context.Context, callback ClientConnectedCallbac
 			default:
 				conn, err := l.Accept()
 				if err != nil {
-					log.Error("failed to accept local socket connection", "localSocket", ra.config.LocalSocket, "remoteSite", ra.config.SiteName, "remoteAppId", ra.config.RemoteAppId, "error", err)
+					log.Error("failed to accept local socket connection", "localSocket", ra.config.LocalSocket, "remoteSite", ra.config.SiteName, "remoteApp", ra.config.AppName, "error", err)
 					return
 				}
-				log.Info("a new client connection request incoming", "clientAddr", conn.RemoteAddr().String(), "remoteAppId", ra.config.RemoteAppId)
-				go callback(ra.config.SiteName, ra.config.RemoteAppId, conn)
+				log.Info("a new client connection request incoming", "clientAddr", conn.RemoteAddr().String(), "remoteApp", ra.config.AppName)
+				go callback(ra.config.SiteName, ra.config.AppName, conn)
 			}
 		}
 	}()
@@ -58,10 +58,10 @@ func (ra *remoteApp) Active() bool {
 
 func (ra *remoteApp) stop() {
 	log := logger.GetDefault()
-	log.Info("stop local socket listener for remote app", "remoteSite", ra.config.SiteName, "appId", ra.config.RemoteAppId, "localSocket", ra.config.LocalSocket)
+	log.Info("stop local socket listener for remote app", "remoteSite", ra.config.SiteName, "remoteApp", ra.config.AppName, "localSocket", ra.config.LocalSocket)
 	err := ra.listener.Close()
 	if err != nil {
-		log.Error("failed to close local socket", "localSocket", ra.config.LocalSocket, "remoteSite", ra.config.SiteName, "remoteAppId", ra.config.RemoteAppId, "error", err)
+		log.Error("failed to close local socket", "localSocket", ra.config.LocalSocket, "remoteSite", ra.config.SiteName, "remoteApp", ra.config.AppName, "error", err)
 	}
 }
 


### PR DESCRIPTION
Use uuid to identify app is not human-friendly (the uuid is meaningless and difficult to remeber)

So, this commit user name to replace it