### PR TITLE
support one app expose multiple sockets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,22 +102,36 @@ tunnel:
       url: https://ipinfo.io/ip
 
 # Specify which applications can be accessed by remote peer sites.
-# The both options appName and appSocket are required.
-# The max lenght of appName is 255, and appName must be unique
-# in the local site. The appSocket is the socket of the local application.
-# The valid socket protocols are tcp and unix.
+# `mode` specifies the method used to expose local APPs, support two values: `single` and `range` (single is default)
+# `appName` must be unique in the local site, with a maximum length of 255 characters
+# `appSocket` specifies the socket address of local site's APP to expose, it must be set when `mode` is `single`
+# it will be ignored when mode set as range
+# `portRange` it must be set when `mode` is `range`, it specifies port range of exposed apps
+# `addressRange` it must be set when `mode` is `range`, it specifies ip address range of exposed Apps
 # 指定本端哪些应用可以被远程对等站点访问
-# 两个参数 appName 和 appSocket 都是必须被设置的
-# appName 的最大长度是 255，且在本地站点中必须唯一
-# appSocket 是本地应用的套接字
-# 当前支持的套接字协议有 tcp 和 unix
+# mode 指定以那种方式暴露本地 APP，当前支持两种方式：single 和 range（默认值为 single）。
+# appName 的最大长度是 255，且在本地站点中必须唯一。
+# appSocket 指定暴露的本端 APP 的套接字地址，当 mode 为 single 时，该值必须本设置，当 mode 为 range 时会忽略该值，
+# 当前支持的 APP 套接字协议有 tcp 和 unix。
+# portRange 当 mode 为 range 时，该项必须被设置，用于指定本端暴露的端口范围。
+# addressRange 当 mode 为 range 时，该项必须被设置，用于指定本端暴露的 ip 地址范围。
 localExposedApps:
 - appSocket: tcp:192.168.122.80:8080
   appName: web
 - appSocket: tcp:127.0.0.1:22
   appName: ssh
+  mode: single
 - appSocket: unix:/var/run/docker.sock
   appName: docker
+- appName: vdi
+  mode: range
+  portRange:
+  - 5900
+  - 5901-5990
+  addressRange:
+  - 10.0.0.6
+  - 10.0.2.0/24
+  - ::1
 
 # Specify the local site can access which remote applications of remote sites
 # All these three options are required.
@@ -138,6 +152,16 @@ remoteApps:
   localSocket: tcp:0.0.0.0:10986
 - siteName: site03
   appName: ssh
-  # convert ipv4 app to ipv6 app
+  # convert ipv4 APP to ipv6 APP
   # 将 ipv4 的应用转换为 ipv6 的应用
   localSocket: tcp:[::1]:20022
+- siteName: site03
+  appName: vdi
+  appSocket: tcp:10.0.2.123:25900
+  localSocket: tcp:10.0.2.2:5900
+# Because the vdi APP has range mode, the appSocket need be specified here
+# 因为 vdi APP 的 mode 为 rang，所以这儿必须要指定 appSocket
+- siteName: site03
+  appName: vdi
+  appSocket: tcp:10.0.2.123:35900
+  localSocket: tcp:10.0.2.3:5900

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -2,49 +2,68 @@ package app
 
 import (
 	"fmt"
-	"net/netip"
-	"slices"
-	"strings"
 )
 
 type LocalExposedAppConfig struct {
-	AppName   string `mapstructure:"appName"`
-	AppSocket string `mapstructure:"appSocket"`
+	Mode         string   `mapstructure:"mode"`
+	AppName      string   `mapstructure:"appName"`
+	AppSocket    string   `mapstructure:"appSocket"`
+	PortRange    []string `mapstructure:"portRange"`
+	AddressRange []string `mapstructure:"addressRange"`
 }
 
 type RemoteAppConfig struct {
 	SiteName    string `mapstructure:"siteName"`
 	AppName     string `mapstructure:"appName"`
 	LocalSocket string `mapstructure:"localSocket"`
+	AppSocket   string `mapstructure:"appSocket"`
 }
 
-var localExposedAppNames = []string{}
-
 func CheckLocalExposedAppConfig(configs []*LocalExposedAppConfig) error {
+	appNames := make(map[string]bool)
+
 	for _, cfg := range configs {
-		if cfg.AppName == "" || cfg.AppSocket == "" {
-			return fmt.Errorf("the appName and appsocket must be set together for local exposed app")
+		if len(cfg.AppName) == 0 {
+			return fmt.Errorf("appName is required")
 		}
 		if len(cfg.AppName) > 255 {
-			return fmt.Errorf("the appName: %s is too long, the max length is 255", cfg.AppName)
+			return fmt.Errorf("appName '%s' exceeds 255 characters", cfg.AppName)
 		}
-		s := strings.SplitN(cfg.AppSocket, ":", 2)
-		if len(s) != 2 {
-			return fmt.Errorf("the appSocket: %s is invalid, the format must be <protocol>:<socket-addr>", cfg.AppSocket)
+		if appNames[cfg.AppName] {
+			return fmt.Errorf("duplicate appName found: '%s'", cfg.AppName)
 		}
-		if !slices.Contains([]string{"tcp", "unix"}, s[0]) {
-			return fmt.Errorf("the appSocket: %s is invalid, the protocol must be tcp or unix", cfg.AppSocket)
+		appNames[cfg.AppName] = true
+
+		if cfg.Mode == "" {
+			cfg.Mode = SINGLE
 		}
-		if strings.ToLower(s[0]) == "tcp" {
-			_, err := netip.ParseAddrPort(s[1])
-			if err != nil {
-				return fmt.Errorf("the appSocket: %s is invalid", cfg.AppSocket)
+
+		switch cfg.Mode {
+		case SINGLE:
+			if cfg.AppSocket == "" {
+				return fmt.Errorf("app '%s' has mode 'single' but missing appSocket", cfg.AppName)
 			}
+			err := isValidSocket(cfg.AppSocket)
+			if err != nil {
+				return fmt.Errorf("app '%s' has invalid appSocket: %s, %w", cfg.AppName, cfg.AppSocket, err)
+			}
+			return nil
+		case RANGE:
+			if len(cfg.PortRange) == 0 {
+				return fmt.Errorf("app '%s' has mode 'range' but missing portRange", cfg.AppName)
+			}
+			if err := validatePortRange(cfg.PortRange); err != nil {
+				return fmt.Errorf("app '%s' has invalid portRange: %w", cfg.AppName, err)
+			}
+			if len(cfg.AddressRange) == 0 {
+				return fmt.Errorf("app '%s' has mode 'range' but missing addressRange", cfg.AppName)
+			}
+			if err := validateAddressRange(cfg.AddressRange); err != nil {
+				return fmt.Errorf("app '%s' has invalid addressRange: %w", cfg.AppName, err)
+			}
+		default:
+			return fmt.Errorf("app '%s' has invalid mode: %s", cfg.AppName, cfg.Mode)
 		}
-		if slices.Contains(localExposedAppNames, cfg.AppName) {
-			return fmt.Errorf("the appName: %s is duplicated", cfg.AppName)
-		}
-		localExposedAppNames = append(localExposedAppNames, cfg.AppName)
 	}
 	return nil
 }
@@ -55,22 +74,17 @@ func CheckRemoteAddConfig(configs []*RemoteAppConfig) error {
 			return fmt.Errorf("the siteName, appName and localSocket must be set together for remote app")
 		}
 		if len(cfg.SiteName) > 255 {
-			return fmt.Errorf("the siteName: %s is too long, the max length is 255", cfg.SiteName)
+			return fmt.Errorf("the siteName: '%s' is too long, the max length is 255", cfg.SiteName)
 		}
 		if len(cfg.AppName) > 255 {
-			return fmt.Errorf("the appName: %s is too long, the max length is 255", cfg.AppName)
+			return fmt.Errorf("the appName: '%s' is too long, the max length is 255", cfg.AppName)
 		}
-		s := strings.SplitN(cfg.LocalSocket, ":", 2)
-		if len(s) != 2 {
-			return fmt.Errorf("the localSocket: %s is invalid, the format must be <protocol>:<socket-addr>", cfg.LocalSocket)
+		if err := isValidSocket(cfg.LocalSocket); err != nil {
+			return fmt.Errorf("the localSocket: '%s' of remot app: '%s' is invalid, %w", cfg.LocalSocket, cfg.AppName, err)
 		}
-		if !slices.Contains([]string{"tcp", "unix"}, s[0]) {
-			return fmt.Errorf("the localSocket: %s is invalid, the protocol must be tcp or unix", cfg.LocalSocket)
-		}
-		if strings.ToLower(s[0]) == "tcp" {
-			_, err := netip.ParseAddrPort(s[1])
-			if err != nil {
-				return fmt.Errorf("the localSocket: %s is invalid", cfg.LocalSocket)
+		if cfg.AppSocket != "" {
+			if err := isValidSocket(cfg.AppSocket); err != nil {
+				return fmt.Errorf("the appSocket: '%s' of remot app: '%s' is invalid, %w", cfg.AppSocket, cfg.AppName, err)
 			}
 		}
 	}

--- a/internal/app/consts.go
+++ b/internal/app/consts.go
@@ -1,0 +1,11 @@
+package app
+
+const (
+	SINGLE string = "single"
+	RANGE  string = "range"
+)
+
+const (
+	TCP  string = "tcp"
+	UNIX string = "unix"
+)

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -22,14 +22,14 @@ func (am *AppManager) GetExposedApps() []LocalExposedApp {
 }
 
 // ConnectToLocalApp get a connection which connect to the local app
-func (am *AppManager) ConnectToLocalApp(appName string) (io.ReadWriteCloser, error) {
+func (am *AppManager) ConnectToLocalApp(appName string, socket string) (io.ReadWriteCloser, error) {
 	log := logger.GetDefault()
 	app, ok := am.localExposedApps[appName]
 	if !ok {
 		log.Error("local app can not found", "localApp", appName)
 		return nil, fmt.Errorf("app: %s can not found", appName)
 	}
-	return app.GetConnection()
+	return app.GetConnection(socket)
 }
 
 // ProcessNewRemoteSite when a new remote site connected successfully, we

--- a/internal/app/remote.go
+++ b/internal/app/remote.go
@@ -13,7 +13,7 @@ import (
 	"gihtub.com/kungze/wovenet/internal/logger"
 )
 
-type ClientConnectedCallback func(remoteSite string, remoteApp string, conn io.ReadWriteCloser)
+type ClientConnectedCallback func(remoteSite string, appName string, appSocket string, conn io.ReadWriteCloser)
 
 type remoteApp struct {
 	config   RemoteAppConfig
@@ -28,7 +28,7 @@ func (ra *remoteApp) listen(ctx context.Context, callback ClientConnectedCallbac
 	if len(s) != 2 {
 		return fmt.Errorf("the localSocket: %s is invalid, the format must be protocol:ipaddr:port", ra.config.LocalSocket)
 	}
-	if strings.ToLower(s[0]) == "unix" {
+	if strings.ToLower(s[0]) == UNIX {
 		// check if the base dir of the socket path exists. if not, create it.
 		dir := filepath.Dir(s[1])
 		err := os.MkdirAll(dir, os.ModePerm)
@@ -69,7 +69,7 @@ func (ra *remoteApp) listen(ctx context.Context, callback ClientConnectedCallbac
 					return
 				}
 				log.Info("a new client connection request incoming", "clientAddr", conn.RemoteAddr().String(), "remoteApp", ra.config.AppName)
-				go callback(ra.config.SiteName, ra.config.AppName, conn)
+				go callback(ra.config.SiteName, ra.config.AppName, ra.config.AppSocket, conn)
 			}
 		}
 	}()

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func isValidSocket(socket string) error {
+	s := strings.SplitN(socket, ":", 2)
+	if len(s) < 2 {
+		return fmt.Errorf("invalid format, the valid format: <protocol>:<socket-addr>")
+	}
+	switch strings.ToLower(s[0]) {
+	case UNIX:
+		if len(s[1]) > 0 {
+			return nil
+		}
+		return fmt.Errorf("invalid unix domain socket")
+	case TCP:
+		host, port, err := net.SplitHostPort(s[1])
+		if err != nil {
+			return fmt.Errorf("invalid tcp socket: %w", err)
+		}
+		if net.ParseIP(host) == nil {
+			return fmt.Errorf("invalid ip address: %s", host)
+		}
+		if !isValidPort(port) {
+			return fmt.Errorf("invalid port: %s", port)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported protoco: %s, supported values: tcp and unix", s[0])
+	}
+}
+
+func isValidPort(port string) bool {
+	p, err := strconv.Atoi(port)
+	return err == nil && p >= 0 && p <= 65535
+}
+
+func validatePortRange(ranges []string) error {
+	rangePattern := regexp.MustCompile(`^(\d+)(?:-(\d+))?$`)
+	for _, r := range ranges {
+		matches := rangePattern.FindStringSubmatch(r)
+		if matches == nil {
+			return fmt.Errorf("invalid port format: %s", r)
+		}
+		start, _ := strconv.Atoi(matches[1])
+		if !isValidPort(matches[1]) {
+			return fmt.Errorf("invalid start port: %s", matches[1])
+		}
+		if matches[2] != "" {
+			end, _ := strconv.Atoi(matches[2])
+			if !isValidPort(matches[2]) {
+				return fmt.Errorf("invalid end port: %s", matches[2])
+			}
+			if end < start {
+				return fmt.Errorf("invalid range: %s (end < start)", r)
+			}
+		}
+	}
+	return nil
+}
+
+func validateAddressRange(addresses []string) error {
+	for _, addr := range addresses {
+		if strings.Contains(addr, "/") {
+			if _, _, err := net.ParseCIDR(addr); err != nil {
+				return fmt.Errorf("invalid CIDR: %s", addr)
+			}
+		} else {
+			if ip := net.ParseIP(addr); ip == nil {
+				return fmt.Errorf("invalid IP address: %s", addr)
+			}
+		}
+	}
+	return nil
+}
+
+// Checks if the given port (int) is within any of the specified port ranges
+func isPortInRange(portStr string, ranges []string) bool {
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return false
+	}
+	for _, r := range ranges {
+		if strings.Contains(r, "-") {
+			parts := strings.Split(r, "-")
+			start, err1 := strconv.Atoi(parts[0])
+			end, err2 := strconv.Atoi(parts[1])
+			if err1 == nil && err2 == nil && port >= start && port <= end {
+				return true
+			}
+		} else {
+			p, err := strconv.Atoi(r)
+			if err == nil && port == p {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Checks if the given IP string belongs to any of the CIDRs or IPs in addressRange
+func isIPInRange(ipStr string, ranges []string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+
+	for _, r := range ranges {
+		if strings.Contains(r, "/") {
+			_, cidrNet, err := net.ParseCIDR(r)
+			if err == nil && cidrNet.Contains(ip) {
+				return true
+			}
+		} else {
+			if rIP := net.ParseIP(r); rIP != nil && rIP.Equal(ip) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
In some cases, on app has multiple sockets. Such as, a VDI system has multiple VMs, each vm has a RDP service or SPICE service, each service listen on a socket. So, a VDI app has to expose multiple socket.

For `localExposedApps`, add `portRange` and `addressRange` to limit the exposed sockets' range

For `remoteApps`，add `appSocket` to specify the `localSocket` access which socket of the app.