### PR TITLE
support automatic setting of `message.mqtt.topic`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,9 +34,12 @@ messageChannel:
     # In other words, the same topic sites will join the same network
     # **If you don't change this value**, you may connect to other sites network, which may cause
     # information leak
+    # If you left this empty, wovenet will automatically generate the value,
+    # the value format: github.com/kungze/wovenet/message-topic-<crypto.key>
     # NOTE: 重要提示：强烈建议你修改这个值（不要使用这个默认值）
     # 相同 topic 的站点之间会尝试互相建立隧道。
     # **如果你不修改这个值**可能会连接到其他的站点网络，造成信息的泄露
+    # 如果设置为空，将会自动生成一个 topic，格式为：github.com/kungze/wovenet/message-topic-<crypto.key>
     topic: "kungze/wovenet/your-own-private-topic"
 
 tunnel:

--- a/internal/message/config.go
+++ b/internal/message/config.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+
+	"github.com/kungze/wovenet/internal/crypto"
 )
 
 type Config struct {
@@ -12,7 +14,7 @@ type Config struct {
 	Mqtt     *mqttConfig `mapstructure:"mqtt"`
 }
 
-func CheckAndSetDefaultConfig(config *Config) error {
+func CheckAndSetDefaultConfig(config *Config, cryptoCfg *crypto.Config) error {
 	if config == nil {
 		return fmt.Errorf("messageChannel is required")
 	}
@@ -21,7 +23,7 @@ func CheckAndSetDefaultConfig(config *Config) error {
 	}
 	if config.Protocol == strings.ToLower(MQTT) {
 		if config.Mqtt.Topic == "" {
-			return fmt.Errorf("the mqtt topic must be set")
+			config.Mqtt.Topic = fmt.Sprintf("github.com/kungze/wovenet/message-topic-%s", cryptoCfg.Key)
 		}
 		if config.Mqtt.BrokerServer == "" {
 			config.Mqtt.BrokerServer = "mqtt://mqtt.eclipseprojects.io:1883"

--- a/internal/site/config.go
+++ b/internal/site/config.go
@@ -31,7 +31,7 @@ func CheckAndSetDefaultConfig(config *Config) error {
 		return err
 	}
 
-	if err := message.CheckAndSetDefaultConfig(config.MessageChannel); err != nil {
+	if err := message.CheckAndSetDefaultConfig(config.MessageChannel, config.Crypto); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
To simplify configuration, if `message.mqtt.topic` is not set, Wovenet will automatically generate the `message.mqtt.topic` based on `crypto.key`.